### PR TITLE
feat: created initial organization of explainers and guides

### DIFF
--- a/src/pages/_app.module.css
+++ b/src/pages/_app.module.css
@@ -3,3 +3,17 @@
 	max-width: 700px;
 	padding: 0 1rem;
 }
+
+.navList {
+	display: flex;
+	list-style: none;
+	padding-left: 0;
+	gap: 1rem;
+	justify-content: center;
+}
+
+.breakItem:after {
+	content: "";
+	border-right: 1px solid black;
+	margin-left: 1rem;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import Link from "next/link";
 
 import styles from "./_app.module.css";
 
@@ -15,9 +16,37 @@ export default function App({ Component, pageProps }: AppProps) {
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
 				<link rel="icon" href="/favicon.ico" />
 			</Head>
+			<header>
+				<ul className={styles.navList}>
+					<li className={styles.breakItem}>
+						<Link href="/">Home</Link>
+					</li>
+					<li>
+						<Link href="/explainers">Explainers</Link>
+					</li>
+					<li className={styles.breakItem}>
+						<Link href="/guides">Guides</Link>
+					</li>
+					<li>
+						<Link href="/about">About</Link>
+					</li>
+					<li>
+						<Link href="/get-involved">Get Involved</Link>
+					</li>
+				</ul>
+			</header>
 			<main className={styles.main}>
 				<Component {...pageProps} />
 			</main>
+			<footer>
+				<ul className={styles.navList}>
+					<li>
+						<Link href="https://github.com/OpenContributionsProject/opencontributionssite">
+							GitHub
+						</Link>
+					</li>
+				</ul>
+			</footer>
 		</>
 	);
 }

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -1,0 +1,60 @@
+# About
+
+The **Open Contributions Project** is an effort to describe and quantify corporate contributions to open source.
+Our goal is to empower employees advocating for open source contributions to their employers. 💙
+
+## Project Goals
+
+We plan on tackling two project focuses, in order of complexity:
+
+- [**Explaining**](#explaining-open-source-contributions): writing convincing, data-backed resources for why open source contributions are in company’s best interests.
+- [**Quantifying**](#quantifying-corporate-open-source-contributions): creating a tracking service that spotlights open source contributions already being done by companies.
+
+## Explaining Open Source Contributions
+
+_We_ know that donating money and time to open source is the correct and right thing for companies to do.
+But financial decision-makers act only when motivated to.
+They need real reasons -ideally metrics- and/or research-based- that demonstrate why potential investments will be net positive for the company.
+
+### Documentation
+
+Our project will start by creating a documentation website explaining:
+
+- **What** open source is, for both non-technical and technical individuals
+- **Why** contributing is beneficial to both the company and their industry
+- **How** can companies contribute: employee time, free services, and/or monetary
+
+We will also create “explainer” documents tailored to:
+
+- Financial leaders (e.g. CFOs)
+- Operations leaders (e.g. COOs)
+- Technical leaders (e.g. CTOs)
+
+### Research
+
+Advocating for a cause to an organization necessitates being able to prove why the cause is worthwhile.
+This often comes via a combination of two forms:
+
+- **Anecdotal**: Real-world stories of how taking on the cause has benefitted organizations
+- **Data**: Showing quantifiable results that seem to reinforce the cause being beneficial
+
+Anecdotally, we have found data-informed approaches to be much more effective in convincing financial decision-makers.
+
+## Quantifying Corporate Open Source Contributions
+
+Once our documentation and explainer pages are filled out on the site, we will expand our scope to becoming a public record of positive open source contributions by companies.
+
+We intend to track two kinds of contributions:
+
+- **Employee time**: During work hours, spending employee time on open source projects
+- **Financial**: Monetary donations, including sponsorship donations and product discounts
+
+Contributions will also be tracked in the context of what kind of recipient open source project:
+
+- **Community**: Projects whose maintainers operate independently of a sole backing company
+- **Maintenance**: Projects whose maintainers answer to and work for a company
+
+We plan on creating open source data initially tracking the larger open source contributions of companies such as Facebook, Github, and Sentry.
+It is will be positioned as a crowdsourced repository similar to DefinitelyTyped or Wikipedia.
+
+We will also investigate augmenting site data automatically when possible, such as with public financial records and APIs for services such as Tidelift.

--- a/src/pages/explainers.md
+++ b/src/pages/explainers.md
@@ -1,0 +1,16 @@
+# Explainers
+
+Wondering what open source is, or why we should contribute to it?
+You're not alone.
+
+Soon, we'll have a set of resources here to help explain open source:
+
+- [🚀 Feature: Add an "explainer" page for what open source is for software developers](https://github.com/OpenContributionsProject/opencontributionssite/issues/21)
+- [🚀 Feature: Add an "explainer" page for what open source is for non-developers](https://github.com/OpenContributionsProject/opencontributionssite/issues/22)
+- [🚀 Feature: Add an "explainer" page for why contributing to open source benefits a company](https://github.com/OpenContributionsProject/opencontributionssite/issues/23)
+- [🚀 Feature: Add an "explainer" page tailored to finance departments](https://github.com/OpenContributionsProject/opencontributionssite/issues/25)
+- [🚀 Feature: Add an "explainer" page tailored to project managers](https://github.com/OpenContributionsProject/opencontributionssite/issues/26)
+- [🚀 Feature: Add an "explainer" page tailored to technical leaders](https://github.com/OpenContributionsProject/opencontributionssite/issues/27)
+
+Want to help us fill these out?
+Let us know on GitHub! 💖

--- a/src/pages/get-involved.md
+++ b/src/pages/get-involved.md
@@ -20,7 +20,7 @@ See our [_area: design_ issues](https://github.com/OpenContributionsProject/open
 
 ## Development
 
-Once the site has a theme and design system specced out, we'll want to implement it.
+Once the site has a theme and design system designed, we'll want to implement it.
 We don't particularly need development resources just yet, but if you're particularly excited then let us know!
 We can find something for you to work on.
 

--- a/src/pages/get-involved.md
+++ b/src/pages/get-involved.md
@@ -1,0 +1,31 @@
+# Get Involved
+
+We'd love to have you help out with the project! ♥️
+
+## Content Writing
+
+Much of this project involves writing explainers and guides for various audiences and goals.
+See our [_area: documentation_ issues](https://github.com/OpenContributionsProject/opencontributionssite/issues?q=is%3Aissue+is%3Aopen+label%3A%22area%3A+documentation%22) for ones you can get started on.
+
+## Data
+
+If you're someone involved in data analytics, data science, or any other kind of related area, it'd be lovely to have you help us quantify the benefits of contributing to open source.
+See our [_area: data gathering_ issues](https://github.com/OpenContributionsProject/opencontributionssite/labels/area%3A%20data%20gathering) for ones you can get started on.
+
+## Design
+
+The site is a little visually bland right now.
+We're going to need to make it presentable, with a full site theme and backing design system.
+See our [_area: design_ issues](https://github.com/OpenContributionsProject/opencontributionssite/labels/area%3A%20data%20gathering) for ones you can get started on.
+
+## Development
+
+Once the site has a theme and design system specced out, we'll want to implement it.
+We don't particularly need development resources just yet, but if you're particularly excited then let us know!
+We can find something for you to work on.
+
+## Other
+
+Not seeing your area of expertise on this page, or want to help us out in some other way?
+We'd like that very much!
+Let us know on GitHub. 🥰

--- a/src/pages/guides.md
+++ b/src/pages/guides.md
@@ -1,0 +1,13 @@
+# Guides
+
+Interested in advocating for contributing to open source, or getting involved yourself?
+Let us help you.
+
+Soon, we'll have a set of resources here to help guide you in advocating for open source:
+
+- [🚀 Feature: Add a guide page explaining how to contribute to open source](https://github.com/OpenContributionsProject/opencontributionssite/issues/24)
+- [🚀 Feature: Add a guide to spending company time on open source](https://github.com/OpenContributionsProject/opencontributionssite/issues/31)
+- [🚀 Feature: Add a guide to advocating for spending company money on open source](https://github.com/OpenContributionsProject/opencontributionssite/issues/52)
+
+Want to help us fill these out?
+Let us know on GitHub! 💖

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -17,7 +17,7 @@ See our [Explainers](./explainers) to understand this incredible movement in sof
 
 Interested in advocating for contributing to open source, or getting involved yourself?
 Let us help you.
-See our [Guides](./guides) for suggestions on how to go about making open source a part of your life.
+Check out our [Guides](./guides) to learn how you can start your open source journey and make a positive impact on the world of software development.
 
 ## Get Involved
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -3,60 +3,24 @@
 An effort to describe and quantify corporate contributions to open source.
 Our goal is to empower employees advocating for open source contributions to their employers. 💙
 
-[Find us on GitHub](https://github.com/OpenContributionsProject/opencontributionssite)!
+You can learn more about us in [About](./about).
 
-## Project Goals
+## Site Contents
 
-We plan on tackling two project focuses, in order of complexity:
+### Explainers
 
-- [**Explaining**](#explaining-open-source-contributions): writing convincing, data-backed resources for why open source contributions are in company’s best interests.
-- [**Quantifying**](#quantifying-corporate-open-source-contributions): creating a tracking service that spotlights open source contributions already being done by companies.
+Wondering what open source is, or why we should contribute to it?
+You're not alone.
+See our [Explainers](./explainers) to understand this incredible movement in software development.
 
-## Explaining Open Source Contributions
+### Guides
 
-_We_ know that donating money and time to open source is the correct and right thing for companies to do.
-But financial decision-makers act only when motivated to.
-They need real reasons -ideally metrics- and/or research-based- that demonstrate why potential investments will be net positive for the company.
+Interested in advocating for contributing to open source, or getting involved yourself?
+Let us help you.
+See our [Guides](./guides) for suggestions on how to go about making open source a part of your life.
 
-### Documentation
+## Get Involved
 
-Our project will start by creating a documentation website explaining:
-
-- **What** open source is, for both non-technical and technical individuals
-- **Why** contributing is beneficial to both the company and their industry
-- **How** can companies contribute: employee time, free services, and/or monetary
-
-We will also create “explainer” documents tailored to:
-
-- Financial leaders (e.g. CFOs)
-- Operations leaders (e.g. COOs)
-- Technical leaders (e.g. CTOs)
-
-### Research
-
-Advocating for a cause to an organization necessitates being able to prove why the cause is worthwhile.
-This often comes via a combination of two forms:
-
-- **Anecdotal**: Real-world stories of how taking on the cause has benefitted organizations
-- **Data**: Showing quantifiable results that seem to reinforce the cause being beneficial
-
-Anecdotally, we have found data-informed approaches to be much more effective in convincing financial decision-makers.
-
-## Quantifying Corporate Open Source Contributions
-
-Once our documentation and explainer pages are filled out on the site, we will expand our scope to becoming a public record of positive open source contributions by companies.
-
-We intend to track two kinds of contributions:
-
-- **Employee time**: During work hours, spending employee time on open source projects
-- **Financial**: Monetary donations, including sponsorship donations and product discounts
-
-Contributions will also be tracked in the context of what kind of recipient open source project:
-
-- **Community**: Projects whose maintainers operate independently of a sole backing company
-- **Maintenance**: Projects whose maintainers answer to and work for a company
-
-We plan on creating open source data initially tracking the larger open source contributions of companies such as Facebook, Github, and Sentry.
-It is will be positioned as a crowdsourced repository similar to DefinitelyTyped or Wikipedia.
-
-We will also investigate augmenting site data automatically when possible, such as with public financial records and APIs for services such as Tidelift.
+We're looking for help in all sorts of areas.
+Especially non-developer roles!
+See [Get Involved](./get-involved) for details.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #55
- [x] That issue was marked as [accepting prs](https://github.com/OpenContributionsProject/opencontributionssite/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/OpenContributionsProject/opencontributionssite/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per the issue, creates a rudimentary header and linked pages:

* Home: The existing homepage, now used as a summary of other pages
* About: What was on the homepage, explaining the project in more detail:
* Explainers: Where we'll collect docs explainers for various audiences & topics
* Guides: Where we'll collect helpful suggestion guides around advocating for open source
* Get Involved: Suggestions for how folks can help out with the project

Also per the issue, applies almost no design thought to the site pending #2 and #20.

<img alt="Screenshot of the new homepage, still very sparse" src="https://user-images.githubusercontent.com/3335181/213881656-1ce492e3-9433-4082-b4fc-9dec26e28971.png">
