### PR TITLE
docs: enable GitHub Codespaces and quickstart guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,17 +3,9 @@
 {
 	"name": "Node.js & TypeScript",
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [8000],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "npm install pnpm; pnpm install",
-	// "postStartCommand": "pnpm run dev",
-	// Configure tool-specific properties.
+	"waitFor": "onCreateCommand",
+	"updateContentCommand": "pnpm install",
+	"postAttachCommand": "pnpm dev",
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -23,9 +15,16 @@
 				"DavidAnson.vscode-markdownlint",
 				"ms-vscode-remote.remote-containers"
 			]
+		},
+		"codespaces": {
+			"openFiles": ["src/pages/_app.tsx"]
 		}
-	}
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	},
+	"portsAttributes": {
+		"3000": {
+			"label": "Application",
+			"onAutoForward": "openPreview"
+		}
+	},
+	"forwardPorts": [3000]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,9 +15,6 @@
 				"DavidAnson.vscode-markdownlint",
 				"ms-vscode-remote.remote-containers"
 			]
-		},
-		"codespaces": {
-			"openFiles": ["src/pages/_app.tsx"]
 		}
 	},
 	"portsAttributes": {

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -54,7 +54,7 @@ The page auto-updates as you edit the file.
 
 When you're done working, you can stop your Codespace by clicking on the `Codespaces` menu in GitHub, finding your Codespace, and selecting `Delete codespace`.
 
-Remember, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
+Remember, every user has 60+ hours of free usage per month. After that, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
 
 ## Technologies
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -1,5 +1,11 @@
 # Development
 
+_Contributors have two options for running and developing this project: locally on your own computer, or using GitHub Codespaces. GitHub Codespaces provides a cloud-hosted development environment, which means you can work on the project without needing to set up anything on your own machine. The instructions below will guide you through both options, allowing you to choose the method that best suits your needs._
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/OpenContributionsProject/opencontributionssite?devcontainer_path=/.devcontainer/basics/devcontainer.json)
+
+## Local Development
+
 After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
 
 ```shell
@@ -20,14 +26,41 @@ pnpm dev
 You can start editing the page by modifying `pages/index.tsx`.
 The page auto-updates as you edit the file. ✨
 
-## Next.js
+## GitHub Codespaces
+
+This project is configured to run in [GitHub Codespaces](https://github.com/features/codespaces), a configurable cloud development environment accessible directly from your GitHub repository.
+
+### Opening the Project in Codespaces
+
+1. Navigate to the main page of the repository.
+2. Click the green `Code` button.
+3. In the dropdown, select `Open with Codespaces`.
+4. Click on `+ New codespace`.
+
+GitHub will create a new Codespace and automatically start the development server for you. This process may take a few minutes.
+
+### Using the Codespace
+
+Once the Codespace is ready, it will open a VS Code interface in your browser. The development server will start running, a port will be forwarded, and a browser preview will open within the Codespace.
+
+You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+
+### Closing the Codespace
+
+When you're done working, you can stop your Codespace by clicking on the `Codespaces` menu in GitHub, finding your Codespace, and selecting `Delete codespace`.
+
+Remember, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
+
+## Technologies
+
+### Next.js
 
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-## Other Dev Tools
+### Other Dev Tools
 
 This repo uses a suite of other development tools to keep code clean.
 It sets up the following tooling for you:

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -1,10 +1,9 @@
 # Development
 
-_Contributors have two options for running and developing this project: locally on your own computer, or using GitHub Codespaces.
-GitHub Codespaces provides a cloud-hosted development environment, which means you can work on the project without needing to set up anything on your own machine.
-The instructions below will guide you through both options, allowing you to choose the method that best suits your needs._
+We provide two preset ways to work on this repository that you can choose from:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/OpenContributionsProject/opencontributionssite?devcontainer_path=/.devcontainer/basics/devcontainer.json)
+* [Local Development](#local-development): Setting up the packages on your local machine
+* [GitHub Codespaces](#github-codespaces): Using a cloud-hosted development environment
 
 ## Local Development
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -54,7 +54,7 @@ The page auto-updates as you edit the file.
 
 When you're done working, you can stop your Codespace by clicking on the `Codespaces` menu in GitHub, finding your Codespace, and selecting `Delete codespace`.
 
-Remember, every user has 60+ hours of free usage per month. 
+Remember, every user has 60+ hours of free usage per month.
 After that, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
 
 ## Technologies

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -2,8 +2,8 @@
 
 We provide two preset ways to work on this repository that you can choose from:
 
-* [Local Development](#local-development): Setting up the packages on your local machine
-* [GitHub Codespaces](#github-codespaces): Using a cloud-hosted development environment
+- [Local Development](#local-development): Setting up the packages on your local machine
+- [GitHub Codespaces](#github-codespaces): Using a cloud-hosted development environment
 
 ## Local Development
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
-_Contributors have two options for running and developing this project: locally on your own computer, or using GitHub Codespaces. GitHub Codespaces provides a cloud-hosted development environment, which means you can work on the project without needing to set up anything on your own machine. The instructions below will guide you through both options, allowing you to choose the method that best suits your needs._
+_Contributors have two options for running and developing this project: locally on your own computer, or using GitHub Codespaces.
+GitHub Codespaces provides a cloud-hosted development environment, which means you can work on the project without needing to set up anything on your own machine.
+The instructions below will guide you through both options, allowing you to choose the method that best suits your needs._
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/OpenContributionsProject/opencontributionssite?devcontainer_path=/.devcontainer/basics/devcontainer.json)
 
@@ -37,13 +39,16 @@ This project is configured to run in [GitHub Codespaces](https://github.com/feat
 3. In the dropdown, select `Open with Codespaces`.
 4. Click on `+ New codespace`.
 
-GitHub will create a new Codespace and automatically start the development server for you. This process may take a few minutes.
+GitHub will create a new Codespace and automatically start the development server for you.
+This process may take a few minutes.
 
 ### Using the Codespace
 
-Once the Codespace is ready, it will open a VS Code interface in your browser. The development server will start running, a port will be forwarded, and a browser preview will open within the Codespace.
+Once the Codespace is ready, it will open a VS Code interface in your browser.
+The development server will start running, a port will be forwarded, and a browser preview will open within the Codespace.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/pages/_app.tsx`.
+The page auto-updates as you edit the file.
 
 ### Closing the Codespace
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -54,7 +54,8 @@ The page auto-updates as you edit the file.
 
 When you're done working, you can stop your Codespace by clicking on the `Codespaces` menu in GitHub, finding your Codespace, and selecting `Delete codespace`.
 
-Remember, every user has 60+ hours of free usage per month. After that, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
+Remember, every user has 60+ hours of free usage per month. 
+After that, Codespaces are billed per usage, so it's a good idea to delete your Codespace when you're not using it.
 
 ## Technologies
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,8 @@ jobs:
           static_site_generator: next
       - uses: ./.github/actions/prepare
       - run: pnpm build
+        env:
+          CUSTOM_BASE_PATH: "/opencontributionssite"
       - run: pnpm next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/cspell.json
+++ b/cspell.json
@@ -30,6 +30,6 @@
 		"rehype",
 		"Rizel",
 		"Scarlett",
-		"vercel",
+		"vercel"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,8 @@
 		"blackgirlbytes",
 		"Codecademy",
 		"codecov",
+		"codespace",
+		"Codespaces",
 		"commitlint",
 		"crowdsourced",
 		"fundable",
@@ -29,7 +31,5 @@
 		"Rizel",
 		"Scarlett",
 		"vercel",
-		"Codespaces",
-		"codespace"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,8 @@
 		"rehype",
 		"Rizel",
 		"Scarlett",
-		"vercel"
+		"vercel",
+		"Codespaces",
+		"codespace"
 	]
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,9 @@ const withMDX = nextMdx({
 });
 
 export default withMDX({
+	...(process.env.CUSTOM_BASE_PATH && {
+		basePath: process.env.CUSTOM_BASE_PATH,
+	}),
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 	reactStrictMode: true,
 });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,9 +12,10 @@ const withMDX = nextMdx({
 });
 
 export default withMDX({
-	...(process.env.CUSTOM_BASE_PATH && {
-		basePath: process.env.CUSTOM_BASE_PATH,
-	}),
+	// ...(process.env.CUSTOM_BASE_PATH && {
+	// 	basePath: process.env.CUSTOM_BASE_PATH,
+	// }),
+	basePath: "/opencontributionssite",
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 	reactStrictMode: true,
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to opencontributionssite! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #16
- [x] That issue was marked as [accepting prs](https://github.com/OpenContributionsProject/opencontributionssite/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/OpenContributionsProject/opencontributionssite/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I enabled this project to install dependencies, build, launch, and show a browser preview of the site in GitHub Codespaces. I did this by adding a development container. I need to add a prebuild to increase the speed of the build, but I will look into the most optimal way to do that in a new ticket. I also added instructions in the ReadMe of how contributors can utilize GitHub Codespaces. The image below shows the view of what contributors should see when they open this project in a Codespace. 

## Testing
To test the experience, you can use this Codespace deep link: https://codespaces.new/galaxy-bytes/opencontributionssite/tree/16-docs-add-quickstart-codespaces

Until merge, this experience will only work on my branch at that deep link.

Please note that I had to use my organization galaxy-bytes because it has unlimited access to Codespaces due to me being GitHub staff. However, my personal blackgirlbytes account reached it's Codespaces usage limit for the month.

 
